### PR TITLE
Added ability to pass `jvmOptions` as an Array

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,7 +233,11 @@ module.exports = (function () {
         }
         
         if (options.jvmOptions) {
-          commandLineOptions.push(options.jvmOptions);
+          if (Array.isArray(options.jvmOptions)) {
+            commandLineOptions.push(...options.jvmOptions);
+          } else {
+            commandLineOptions.push(options.jvmOptions);
+          }
         }
         commandLineOptions.push('-jar');
         commandLineOptions.push(glob.sync('**/mockserver-netty-*-jar-with-dependencies.jar'));


### PR DESCRIPTION
Made it possible to pass `jvmOptions` as an Array of Strings and not as String.

The problems was that node `spawn` function takes arguments as an array, and if we pass multiple arguments as one array member - it trasmits it also as one argument, not two.

----------------------------------------------------------------------

### Here is a code snippet to demonstrate

#### index.js:
```javascript
const spawn = require('child_process').spawn;

const res = spawn('node', [
  'log_arguments.js', 
  'two', 
  'three four'
]);

res.stdout.on('data', (data) => console.log(data.toString()));
```

#### log_arguments.js:
```javascript
process.argv.forEach((arg, i) => { 
  console.log(`Argument (${i}): `, arg);
})
```

After `node index.js` the output is:
```
Argument (0):  /home/vtymoshchyk/.nvm/versions/node/v12.18.4/bin/node
Argument (1):  /home/vtymoshchyk/sandboxes/sandbox-js/log_arguments.js
Argument (2):  two
Argument (3):  three four
```

As you see, the words `three` and `four` are passed as a single argument