### PR TITLE
Improve startup performance on large repos

### DIFF
--- a/downloadJar.js
+++ b/downloadJar.js
@@ -25,7 +25,7 @@
         port: 443
       };
   
-      var currentMockServerJars = glob.sync('**/mockserver-netty-*-jar-with-dependencies.jar');
+      var currentMockServerJars = glob.sync(__dirname + '/mockserver-netty-*-jar-with-dependencies.jar');
       currentMockServerJars.forEach(function (item) {
         if (item.indexOf(dest) === -1 || snapshot) {
           fs.unlinkSync(item);
@@ -35,7 +35,7 @@
         }
       });
   
-      if (glob.sync('**/' + dest).length === 0) {
+      if (!fs.existsSync(__dirname + '/' + dest)) {
         if (logLevel) {
           console.log('Fetching ' + JSON.stringify(options, null, 2));
         }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@
  * Licensed under the Apache License, Version 2.0
  */
 
-const glob = require("glob");
 module.exports = (function () {
 
     var mockServer;


### PR DESCRIPTION
As described in Issue #43 the glob patterns used in `downloadJar.js` are inefficient in large repositories because they scan the whole `node_modules` folder as well as the rest of the project.

We know that the `.jar` files can only be inside the `node_modules/mockserver-node` directory, so we can only check this directory. Therefore the startup time is always the same, and does not increase with the size of the project.